### PR TITLE
feat: add Docker Compose setup with PostgreSQL and pgAdmin services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  db:
+    image: postgres:16
+    container_name: otpbuild-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - pgnetwork
+
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: otpbuild-pgadmin
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "5050:80"
+    depends_on:
+      - db
+    networks:
+      - pgnetwork
+
+volumes:
+  pgdata:
+
+networks:
+  pgnetwork:


### PR DESCRIPTION
This pull request introduces a `docker-compose.yml` file to set up a local PostgreSQL database and a PgAdmin instance for database management. The configuration includes services, volumes, and networks to streamline the development environment.

### Added services for database and management:

* **PostgreSQL service**: Configured a `db` service using the `postgres:16` image, with environment variables for the password, data persistence through a named volume (`pgdata`), and network isolation (`pgnetwork`). It exposes port `5432`.
* **PgAdmin service**: Configured a `pgadmin` service using the `dpage/pgadmin4` image to provide a web-based interface for managing the database. It uses environment variables for credentials, depends on the `db` service, and exposes port `5050`.

### Infrastructure setup:

* **Volumes**: Added a named volume `pgdata` to persist PostgreSQL data.
* **Networks**: Defined a custom network `pgnetwork` to isolate the services.